### PR TITLE
Remove use of env vars for firebase configs (temp)

### DIFF
--- a/src/commons/utils/Firebase.ts
+++ b/src/commons/utils/Firebase.ts
@@ -2,12 +2,12 @@ import { initializeApp } from "firebase/app"
 import { getFirestore, connectFirestoreEmulator } from "firebase/firestore"
 
 const firebaseConfig = {
-  apiKey: process.env.REACT_APP_FIREBASE_API_KEY,
-  authDomain: process.env.REACT_APP_FIREBASE_AUTH_DOMAIN,
-  projectId: process.env.REACT_APP_FIREBASE_PROJECT_ID,
-  appId: process.env.REACT_APP_FIREBASE_APP_ID,
+  apiKey: "AIzaSyDo4HDKDpkXlAlQovTYvIPekhizZUn3o8Y",
+  authDomain: "shelf-gg.firebaseapp.com",
+  projectId: "shelf-gg",
+  appId: "1:404360518247:web:fdc51154b5d10ce84892c2",
 }
-  
+
 const firebase = initializeApp(firebaseConfig);
 const db = getFirestore(firebase)
 

--- a/src/pages/build-shelf/BuildShelf.tsx
+++ b/src/pages/build-shelf/BuildShelf.tsx
@@ -30,8 +30,8 @@ function Create(): JSX.Element {
     formAlert.set(defaultFormAlert)
 
     const created = Date.now()
-    const title = data.title || "Untitled"
-    const creator = data.creator || "Anonymous"
+    const title = data.title.substring(0, 50) || "Untitled"
+    const creator = data.title.substring(0, 50) || "Anonymous"
     const urls = getFilteredUrls(data.resources)
     const views = 0
 
@@ -99,8 +99,6 @@ function Create(): JSX.Element {
     for (const url of urls) {
       const docRef = doc(db, "resources", urlToAlphanumeric(url))
       
-      console.log(docRef)
-
       await getDoc(docRef)
         .then((doc) => {
           if (doc.exists()) {


### PR DESCRIPTION
Temporarily hard-coded non-secret firebase config values as the .env isn't being pushed, so I'll need to update GH actions to work with public & secret env vars.